### PR TITLE
Original file can't be imported in API Management

### DIFF
--- a/apis/httpbin.swagger.json
+++ b/apis/httpbin.swagger.json
@@ -6,7 +6,7 @@
     "version": "1.0"
   },
   "host": "httpbin.org",
-  "basePath": "",
+  "basePath": "/",
   "schemes": [
     "http",
     "https"


### PR DESCRIPTION
The original httpbin.swagger.json can't be imported in Azure API Management. I modified line 9, so that 'basePath' gets value "/". After this change the file can be imported in API Management successfully.