### PR TITLE
Add example to route percentage of traffic to canary backend

### DIFF
--- a/policies/Route percentage of traffic to canary.policy.xml
+++ b/policies/Route percentage of traffic to canary.policy.xml
@@ -1,0 +1,8 @@
+<!-- Copy this snippet into the inbound element to direct a percentage of traffic to a canary backend URL -->
+<set-variable name="canaryPercentage" value="@(15)"/>
+<set-backend-service base-url="https://azfuncapi.azure-api.net/azfunchttpappsvc/api/HttpTriggerCSharp1"/>
+<choose>
+    <when condition="@(context.Variables.GetValueOrDefault<int>("canaryPercentage") < (new Random().Next(1, 100)))">
+        <set-backend-service base-url="https://azfuncapi.azure-api.net/azfuncappsvc1/api/HttpTriggerCSharp1"/>
+    </when>
+</choose>


### PR DESCRIPTION
Thought this might be useful for some people. Since the random number generator is going to get instantiated every time anyway, I was able to take the load balancing policy as a starting point and modify it to route a percentage of traffic (such as one might do with a canary deployment) in a fairly concise policy snippet.